### PR TITLE
Margin around counter fixed

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -185,6 +185,10 @@
             padding: 0.2em 0.5em;
             margin-bottom: 0.5em;
         }
+       
+        .countdown__item {
+          margin-right: 1em;
+      }
 
         .countdown__subText {
             color: #676767;
@@ -284,6 +288,10 @@
             .card1-text {
                 font-size: 1.05em;
             }
+   
+            .countdown__item {
+          margin-right: 1em;
+      }
 
             #welcome-story {
                 font-size: 1.2em;


### PR DESCRIPTION
The countdown is not well spaced on mobile. 
The before and after screenshot of the feature fixed. 
![Screenshot_2019-10-12-06-51-45](https://user-images.githubusercontent.com/50958501/66697006-6d6dba00-ecc9-11e9-85a9-94750b504cce.png)

![Screenshot_2019-10-12-08-17-52](https://user-images.githubusercontent.com/50958501/66697024-92622d00-ecc9-11e9-91e6-f823c86e2a9c.png)
