### PR TITLE
changed sponsor logos into carousel to occupy less space

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -777,6 +777,7 @@ margin-left: 5px;
   padding-top: 1.5em;
   width: 100%;
   padding-bottom: 1em;
+  text-align: center;
 }
 
 .sponsors__header {
@@ -790,26 +791,29 @@ margin-left: 5px;
 }
 
 .sponsors__images {
+  height:100%;
   padding-left: 15.83%;
   padding-right: 15.83%;
   margin-top: 94px;
-  display: flex;
-  justify-content: space-between;
+  /* display: flex; */
+  /* justify-content: space-between; */
 }
 
 .hng_logo {
-  /* width: 167.12px; */
-  height: 52.89px;
+  width: 167.12px !important;
+  height: 55px;
+  margin-bottom:25px;
 }
 
 .akwa_logo {
-  height: 55px;
-  width: 55px;
+  height: 80px ;
+  width: 80px !important;
 }
 
 .verifi_logo {
-  width: 115.4px;
-  height: 52.89px;
+  width: 115.4px !important;
+  height: 55px;
+  margin-bottom:25px;
 }
 
 .sponsors__images2 {
@@ -821,19 +825,44 @@ margin-left: 5px;
 }
 
 .figma_logo {
-  line-height: 26.84px;
+  /* line-height: 26.84px ; */
   font-size: 30px;
+  height:55px;
+  margin: 0;
+  padding: 0;
+  margin-bottom:25px;
 }
 
 .bluechip_logo {
-  /* height: 55px; */
-  width: 153.8px;
+  height: 55px;
+  width: 163.8px !important;
+  margin-bottom:25px;
 }
 
 .flutter_logo {
-  width: 298.16px;
+  height: 55px;
+  width: 298.16px !important;
+  margin-bottom:25px;
 }
-
+.slide{
+  position: relative;
+}
+.carousel-indicators{
+  position: absolute;
+  top:90px;
+  z-index:10;
+}
+.carousel-indicators li{
+  background-color: lightgrey;
+  opacity:0.2;
+}
+.carousel-indicators li:active{
+  opacity:0.3;
+}
+.carousel-control-next , .carousel-control-prev{
+  background-color: rgba(60, 107, 126, 0.1);
+  background-size: 20px 20px;
+}
  .sponsors_button {
   text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -614,37 +614,50 @@ updateClock();
             <section class="sponsors">
                 <h3 class="sponsors__header">HNG 6.0 Internship Sponsors</h3>
                 <div class="sponsors_images_container">
-                    <div class="sponsors__images">
-                        <div class="image2 image1">
-                            <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730789/hostelPic_u2oqax.png"
-                                class="hng_logo">
-                        </div>
-                        <div class="image2 image1">
-                            <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730696/akwa-ibom_crs3gb.png"
-                                class="akwa_logo">
-                        </div>
-                        <div class="image2 image1">
-                            <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730861/imo-logo_xepy5p.png"
-                                class="akwa_logo">
-                        </div>
-                        <div class="image2 image1">
-                            <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730875/VerifiPic_dhgplz.png"
-                                class="verifi_logo">
-                        </div>
-
-                    </div>
-                    <div class="sponsors__images2">
-                        <div class="image2 image1">
-                            <h4 class="figma_logo">Figma</h4>
-                        </div>
-                        <div class="image2 image1">
-                            <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730701/BluePic_ujoey7.png"
-                                class="bluechip_logo">
-                        </div>
-                        <div class="image3">
-                            <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730716/flutterwave_fkjzd7.png"
-                                class="flutter_logo">
-                        </div>
+                    <div class="sponsors__images">                       
+                        <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
+                            <ol class="carousel-indicators">
+                              <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="2"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="3"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="4"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="5"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="6"></li>
+                              <li data-target="#carouselExampleIndicators" data-slide-to="6"></li>
+                            </ol>
+                            <div class="carousel-inner">
+                              <div class="carousel-item active">
+                                <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730789/hostelPic_u2oqax.png" class=" hng_logo" alt="HNG Logo">
+                              </div>
+                              <div class="carousel-item">
+                                <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730696/akwa-ibom_crs3gb.png" class=" akwa_logo" alt="Government of Akwa Ibom logo">
+                              </div>
+                              <div class="carousel-item">
+                                <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730861/imo-logo_xepy5p.png" class=" akwa_logo" alt="Government of Imo logo">
+                              </div>
+                              <div class="carousel-item">
+                                <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730875/VerifiPic_dhgplz.png" class=" verifi_logo" alt="Verifi logo">
+                              </div>
+                              <div class="carousel-item">
+                                <h4 class="figma_logo">Figma</h4>
+                              </div>
+                              <div class="carousel-item">
+                                <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730716/flutterwave_fkjzd7.png" class=" flutter_logo" alt="Flutterwave logo">
+                              </div>
+                              <div class="carousel-item">
+                                <img src="https://res.cloudinary.com/chibuogwu/image/upload/v1570730701/BluePic_ujoey7.png" class=" bluechip_logo" alt="Bluechip logo">
+                              </div>
+                            </div>
+                            <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+                              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                              <span class="sr-only">Previous</span>
+                            </a>
+                            <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+                              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                              <span class="sr-only">Next</span>
+                            </a>
+                          </div>
 
                     </div>
                 </div>


### PR DESCRIPTION
I worked on the sponsor logos on the home page to make them into carousels instead of flexing them as they were before taking lot of spaces particularly on mobile.
I also added manual override controls and indicators

Test link: https://laplace-a.github.io/HNG6.0/index.html